### PR TITLE
Add backtrace to panic log entry, make it opt-out

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -3,7 +3,7 @@ name: Rust
 on:
   push:
     branches:
-      - main 
+      - main
   pull_request:
     types: [ opened, synchronize, reopened ]
     branches:
@@ -23,7 +23,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Rust Cache Action
         uses: Swatinem/rust-cache@v2
-      - name: Run tests
+      - name: Run tests (no-default-features)
+        run: cargo test --no-default-features
+      - name: Run tests (with default features)
         run: cargo test
 
   fmt:
@@ -46,5 +48,7 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - name: Linting
+      - name: Linting (no-default-features)
+        run: cargo clippy --no-default-features -- -D warnings
+      - name: Linting (with default features)
         run: cargo clippy -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ description = "A panic hook that captures panic information as a tracing event"
 keywords = ["logging", "tracing", "panic", "telemetry", "hook"]
 categories = ["development-tools::debugging"]
 
+[features]
+default = ["capture-backtrace"]
+capture-backtrace = []
+
 [dependencies]
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! A panic hook that emits an error-level `tracing` event when a panic occurs.
 //!
 //! Check out [`panic_hook`]'s documentation for more information.
-use std::panic::PanicInfo;
+use std::{backtrace::Backtrace, panic::PanicInfo};
 
 /// A panic hook that emits an error-level `tracing` event when a panic occurs.
 ///
@@ -62,10 +62,12 @@ pub fn panic_hook(panic_info: &PanicInfo) {
     };
 
     let location = panic_info.location().map(|l| l.to_string());
+    let backtrace = cfg!(feature = "capture-backtrace").then(Backtrace::force_capture);
 
     tracing::error!(
         panic.payload = payload,
         panic.location = location,
+        panic.backtrace = backtrace.map(tracing::field::display),
         "A panic occurred",
     );
 }
@@ -89,6 +91,34 @@ mod tests {
 
         let logs = String::from_utf8(buffer.lock().unwrap().clone()).unwrap();
         assert!(logs.contains("This is a static panic message"));
+    }
+
+    #[cfg(feature = "capture-backtrace")]
+    #[test]
+    fn panic_has_backtrace() {
+        let buffer = Arc::new(Mutex::new(vec![]));
+        let _guard = init_subscriber(buffer.clone());
+        let _ = std::panic::catch_unwind(|| {
+            std::panic::set_hook(Box::new(panic_hook));
+            panic!("This is a static panic message");
+        });
+
+        let logs = String::from_utf8(buffer.lock().unwrap().clone()).unwrap();
+        assert!(logs.contains("backtrace"));
+    }
+
+    #[cfg(not(feature = "capture-backtrace"))]
+    #[test]
+    fn panic_has_no_backtrace() {
+        let buffer = Arc::new(Mutex::new(vec![]));
+        let _guard = init_subscriber(buffer.clone());
+        let _ = std::panic::catch_unwind(|| {
+            std::panic::set_hook(Box::new(panic_hook));
+            panic!("This is a static panic message");
+        });
+
+        let logs = String::from_utf8(buffer.lock().unwrap().clone()).unwrap();
+        assert!(!logs.contains("backtrace"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ pub fn panic_hook(panic_info: &PanicInfo) {
         panic.payload = payload,
         panic.location = location,
         panic.backtrace = backtrace.map(tracing::field::display),
-        panic.note = note.map(tracing::field::display),
+        panic.note = note,
         "A panic occurred",
     );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,14 +67,9 @@ pub fn panic_hook(panic_info: &PanicInfo) {
     let location = panic_info.location().map(|l| l.to_string());
     let (backtrace, note) = if cfg!(feature = "capture-backtrace") {
         let backtrace = Backtrace::capture();
-        if let BacktraceStatus::Disabled = backtrace.status() {
-            (
-                Some(backtrace),
-                Some("run with RUST_BACKTRACE=1 environment variable to display a backtrace"),
-            )
-        } else {
-            (Some(backtrace), None)
-        }
+        let note = (backtrace.status() == BacktraceStatus::Disabled)
+            .then_some("run with RUST_BACKTRACE=1 environment variable to display a backtrace");
+        (Some(backtrace), note)
     } else {
         (None, None)
     };


### PR DESCRIPTION
Hello,

Having a backtrace for a panic can be really useful for debugging. If the user considers this undesirable, they may opt out by using `default-features = false`.