### PR TITLE
Reduce dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Other
+- Reduce dependencies
+
 ## [0.1.1](https://github.com/LukeMathWalker/tracing-panic/compare/v0.1.0...v0.1.1) - 2023-05-22
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-panic"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/LukeMathWalker/tracing-panic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ default = ["capture-backtrace"]
 capture-backtrace = []
 
 [dependencies]
-tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing = { version = "0.1", default-features = false, features = ["std"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! Check out [`panic_hook`]'s documentation for more information.
 use std::{
     backtrace::{Backtrace, BacktraceStatus},
-    panic::PanicInfo,
+    panic::PanicHookInfo,
 };
 
 /// A panic hook that emits an error-level `tracing` event when a panic occurs.
@@ -57,7 +57,7 @@ use std::{
 ///     }));
 /// }
 /// ```
-pub fn panic_hook(panic_info: &PanicInfo) {
+pub fn panic_hook(panic_info: &PanicHookInfo) {
     let payload = panic_info.payload();
 
     #[allow(clippy::manual_map)]


### PR DESCRIPTION
While replacing `lazy_static` with `std::sync::LazyLock`, I realized that `tracing-panic` was still pulling it. This PR disables unneeded features from `tracing` and `tracing-subscriber`.